### PR TITLE
docs: specify --node flag in dfclient start command

### DIFF
--- a/docs/en-us/quickstart.md
+++ b/docs/en-us/quickstart.md
@@ -68,13 +68,13 @@ docker pull dragonflyoss/dfclient:0.3.1
 2. execute the command on the first of the two nodes to start dfclient
 
 ```bash
-docker run -d --name dfclient01 -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io
+docker run -d --name dfclient01 -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io --node <SUPERNODE IP>:8002
 ```
 
 3. execute the command on the second of the two nodes to start dfclient
 
 ```bash
-docker run -d --name dfclient02 -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io
+docker run -d --name dfclient02 -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io --node <SUPERNODE IP>:8002
 ```
 
 ## Step 4：Validate Dragonfly

--- a/docs/zh-cn/quickstart.md
+++ b/docs/zh-cn/quickstart.md
@@ -20,10 +20,10 @@ docker run -d --name supernode --restart=always -p 8001:8001 -p 8002:8002 \
 ## 步骤 2：部署 Dragonfly 客户端
 
 ```bash
-docker run -d --name dfclient -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io
+docker run -d --name dfclient -p 65001:65001 dragonflyoss/dfclient:0.3.1 --registry https://index.docker.io --node 127.0.0.1:8002
 ```
 
-> **提示**：`--registry`参数指定镜像仓库地址，`https://index.docker.io`为官方镜像仓库，您也可以设置为其他仓库地址。
+> **提示**：`--registry`参数指定镜像仓库地址，`https://index.docker.io`为官方镜像仓库，您也可以设置为其他仓库地址；`--node`参数指定 supernode 的监听地址，`127.0.0.1:8002`仅在服务端和客户端同机情况下才可使用。
 
 ## 步骤 3：修改 Docker Daemon 配置
 


### PR DESCRIPTION
Without `--node`, the default supernode address will be `127.0.0.1:8002`.
If dfclient is not on the same node as supernode, this will be wrong.

```
2020-05-15 10:10:49.258 WARN sign:82-1589537449.144 : start peer server error:EOF, change to CDN pattern
2020-05-15 10:10:49.258 INFO sign:82-1589537449.144 : do register to one of [127.0.0.1:8002 127.0.0.1:8002]
2020-05-15 10:10:49.258 INFO sign:82-1589537449.144 : do register to 127.0.0.1:8002, res:null error:dial tcp4 127.0.0.1:8002: connect: connection refused
2020-05-15 10:10:49.258 ERRO sign:82-1589537449.144 : register to node:127.0.0.1:8002 error:dial tcp4 127.0.0.1:8002: connect: connection refused
2020-05-15 10:10:49.258 INFO sign:82-1589537449.144 : do register to 127.0.0.1:8002, res:null error:dial tcp4 127.0.0.1:8002: connect: connection refused
2020-05-15 10:10:49.258 ERRO sign:82-1589537449.144 : register to node:127.0.0.1:8002 error:dial tcp4 127.0.0.1:8002: connect: connection refused
2020-05-15 10:10:49.258 ERRO sign:82-1589537449.144 : register fail:{"Code":-100,"Msg":"dial tcp4 127.0.0.1:8002: connect: connection refused"}
...
```